### PR TITLE
add -m flag to view_benchmarks --scaling

### DIFF
--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -93,7 +93,7 @@ jobs:
       - name: create plots
         run: |
           python -m qutip_benchmark.cli.view_benchmarks --nightly --plotpath website/images/plots/nightly
-          python qutip_benchmark.cli.view_benchmarks --scaling --plotpath website/images/plots/scaling
+          python -m qutip_benchmark.cli.view_benchmarks --scaling --plotpath website/images/plots/scaling
 
       - name: publish website
         run: | 


### PR DESCRIPTION
The second call to qutip_benchmark.cli.view_benchmark was lacking the -m flag to call it as a module.