### PR TITLE
Fix typo, clarify landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -10,7 +10,7 @@ title: Quantum Toolbox in Python
 
 <div class="row">
     <div class="col-md-12">
-        <p>welcome to qutip benchmarks please chose an operation</p>
+        <p>Welcome to QuTiP benchmarks: Please choose an operation from the menu above.</p>
     </div>
     </div>
 


### PR DESCRIPTION
Right now one can be prompted to think that the landing page is not working. I thought so and so did a coworker. This is a first fix to clarify a bit more how it works. I still recommend to add a summary of benchmarks on the landing page, instead of keeping it blank.