### PR TITLE
Use mamba to install additional packages instead of conda

### DIFF
--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -39,10 +39,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-           conda install numpy scipy cython
-           conda install pytest pytest-benchmark
-           conda install pandas matplotlib
-           python -m pip install pygal pygaljs
+           mamba install numpy scipy cython
+           mamba install pytest pytest-benchmark
+           mamba install pandas matplotlib
 
       - name: Install Qutip
         run: |
@@ -50,7 +49,7 @@ jobs:
 
       - name: Package information
         run: |
-          conda list
+          mamba list
           python -c "import qutip; qutip.about()"
 
       - name: Environment information

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -3,7 +3,7 @@ name: Test Benchmarks
 
 on:
   [push, pull_request]
-  
+
 
 defaults:
   run:
@@ -39,18 +39,17 @@ jobs:
 
       - name: Install dependencies
         run: |
-           conda install numpy scipy cython
-           conda install pytest pytest-benchmark
-           conda install pandas matplotlib
-           python -m pip install pygal pygaljs
-           
+           mamba install numpy scipy cython
+           mamba install pytest pytest-benchmark
+           mamba install pandas matplotlib
+
       - name: Install Qutip
         run: |
            python -m pip install git+https://github.com/qutip/qutip@dev.major
-    
+
       - name: Package information
         run: |
-          conda list
+          mamba list
           python -c "import qutip; qutip.about()"
       - name: Environment information
         run: |
@@ -64,9 +63,9 @@ jobs:
       - name: Run benchmarks
         run: |
           python -m qutip_benchmark.cli.run_benchmarks -v
-        
+
       - name: Create artefact containing benchmarks
         uses: actions/upload-artifact@v2
-        with: 
+        with:
           name: test_benchmarks
           path: .benchmarks


### PR DESCRIPTION
This also removes the installation of a couple of unused dependencies (pygal and pygaljs).