### PR TITLE
Fix gem install permission issue by installing locally

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build website with Jekyll
         run: |
-          sudo gem install bundler jekyll
+          gem install --user-install bundler jekyll
           sudo apt-get install subversion
           cd website
 


### PR DESCRIPTION
Even with the sudo, the installation raise `PermissionError`. This try to do a local installation instead.