### PR TITLE
Fix the failing installation of bundler in the publish step.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build website with Jekyll
         run: |
-          sudo gem install jekyll
+          sudo gem install bundler jekyll
           sudo apt-get install subversion
           cd website
 
@@ -66,7 +66,8 @@ jobs:
           cp -r _includes_extra/* _includes
 
           # build the website
-          jekyll build
+          bundler install
+          bundler exec jekyll build
 
       - name: Publish benchmarks
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,8 @@ jobs:
 
           # build the website
           bundle config path .gems
-          bundler install
-          bundler exec jekyll build
+          bundle install
+          bundle exec jekyll build
 
       - name: Publish benchmarks
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build website with Jekyll
         run: |
-          gem install --user-install bundler jekyll
+          sudo gem install jekyll
           sudo apt-get install subversion
           cd website
 
@@ -66,8 +66,7 @@ jobs:
           cp -r _includes_extra/* _includes
 
           # build the website
-          bundle install
-          bundle exec jekyll build
+          jekyll build
 
       - name: Publish benchmarks
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,7 @@ jobs:
           cp -r _includes_extra/* _includes
 
           # build the website
+          bundle config path .gems
           bundler install
           bundler exec jekyll build
 


### PR DESCRIPTION
# Description

Doing `sudo gem install bundler` used to work, but a recent update to Ubuntu images in the GitHub action works seems to have broken then. A previous attempt to install bundler locally in #42 cause the bundler executable to not be on the path. This PR aims to sort everything out.

**Update**: The issue was caused by an update to bundler 2.4.x. Before 2.4.x, bundler would automatically run sudo to upgrade its permissions (wat). The behaviour from 2.4.x onwards is much more sane (i.e. it doesn't sudo itself) but it means the gem install path needs to be given explicitly.

Tried so far:

- Try run jekyll without bundler since we have no GemSpec to install (does not work because we need to install our gems from our GemFile -- doh).
- Set the bundle install path (works).

# Related
- #42 