### PR TITLE
Fix failings nightly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,21 +6,21 @@ jobs:
   lint-black:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: "actions/checkout@v2"
+      - name: Checkout
+        uses: "actions/checkout@v4"
 
-      - name: Setup Python 
+      - name: Setup Python
         uses: "actions/setup-python@v2"
         with:
           python-version: "3.10"
-     
+
       - name: Black
         uses: psf/black@stable
         with:
           options: "--line-length 79 --check --diff"
           src: "./qutip_benchmark"
 
-      - name: Install dependencies 
+      - name: Install dependencies
         run: |
           python -VV
           python -m site

--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -16,8 +16,10 @@ defaults:
 
 jobs:
   benchmarks:
+    # if: github.repository == 'qutip/qutip-benchmark'
     name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +28,7 @@ jobs:
         case-name: [defaults]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: actions-bench

--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -16,7 +16,8 @@ defaults:
 
 jobs:
   benchmarks:
-    # if: github.repository == 'qutip/qutip-benchmark'
+    # Prevent running in all the forks
+    if: github.repository == 'qutip/qutip-benchmark'
     name: ${{ matrix.os }}, python${{ matrix.python-version }}, ${{ matrix.case-name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # if: ${{ github.repository == 'qutip/qutip-benchmark' && github.ref == 'refs/heads/master' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # if: ${{ github.repository == 'qutip/qutip-benchmark' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.repository == 'qutip/qutip-benchmark' && github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
         case-name: [defaults]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: actions-bench

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.benchmarks
 nosetests.xml
 
 # Translations

--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -169,7 +169,8 @@ def bench_steadystate(benchmark, model_steady, size):
     benchmark.group = "solvers:steadystate"
 
     if model_steady == "Cavity":
-        pytest.skipif(size >= 128, "Too slow")
+        if size >= 128:
+            pytest.skip("Slow test")
         H, _, c_ops, _ = cavity_setup(size)
 
     elif model_steady == "Jaynes-Cummings":

--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -160,7 +160,7 @@ def bench_mcsolve(benchmark, model_solve, size):
     elif model_solve == "Qubit Spin Chain":
         H, psi0, c_ops, e_ops = qubit_setup(size)
 
-    result = benchmark(mcsolve, H, psi0, tlist, c_ops, e_ops)
+    result = benchmark(mcsolve, H, psi0, tlist, c_ops, e_ops, ntraj=1)
     return result
 
 
@@ -169,6 +169,7 @@ def bench_steadystate(benchmark, model_steady, size):
     benchmark.group = "solvers:steadystate"
 
     if model_steady == "Cavity":
+        pytest.skipif(size>=128, "Too slow")
         H, _, c_ops, _ = cavity_setup(size)
 
     elif model_steady == "Jaynes-Cummings":

--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -169,7 +169,7 @@ def bench_steadystate(benchmark, model_steady, size):
     benchmark.group = "solvers:steadystate"
 
     if model_steady == "Cavity":
-        pytest.skipif(size>=128, "Too slow")
+        pytest.skipif(size >= 128, "Too slow")
         H, _, c_ops, _ = cavity_setup(size)
 
     elif model_steady == "Jaynes-Cummings":

--- a/qutip_benchmark/cli/run_benchmarks.py
+++ b/qutip_benchmark/cli/run_benchmarks.py
@@ -53,6 +53,9 @@ def run_benchmarks(args):
             "--benchmark-columns=Mean,StdDev,rounds,Iterations",
             "--benchmark-sort=name",
             "--benchmark-autosave",
+            "--benchmark-max_time=3.0",
+            "--durations=0",
+            "--durations-min=1.0",
             "-Wdefault",
         ]
         + args

--- a/qutip_benchmark/cli/run_benchmarks.py
+++ b/qutip_benchmark/cli/run_benchmarks.py
@@ -53,7 +53,6 @@ def run_benchmarks(args):
             "--benchmark-columns=Mean,StdDev,rounds,Iterations",
             "--benchmark-sort=name",
             "--benchmark-autosave",
-            "--benchmark-max_time=3.0",
             "--durations=0",
             "--durations-min=1.0",
             "-Wdefault",

--- a/qutip_benchmark/view_utilities.py
+++ b/qutip_benchmark/view_utilities.py
@@ -465,7 +465,6 @@ def plot_data(data, x_axis, y_axis, x_log, y_log, path):
     markers = ["o--", "x-", "v:", "1-.", "*:"]
     i = 0
     for plot in data:
-
         line_sep = data[plot]["line_sep"]
         df = data[plot]["data"]
         cols = list(df.columns)


### PR DESCRIPTION
Fix issues with daily automated benchmarks.
- Update checkout version.
- Nightly benchmarks only run on qutip project
- Skip the slowest test, probably not needed anymore but timeout were an issue.
- explicitly set timeout time to 20 min.
- Add `.benchmarks` to `.gitignore`