### PR TITLE
Add dia data layer to benchmarks

### DIFF
--- a/qutip_benchmark/benchmarks/bench_linear_algebra.py
+++ b/qutip_benchmark/benchmarks/bench_linear_algebra.py
@@ -107,8 +107,6 @@ def bench_add(benchmark, left_oper, right_oper):
     # Run benchmark
     result = benchmark(add, left_oper, right_oper)
 
-    return result
-
 
 @pytest.mark.nightly
 def bench_matmul_oper_oper(benchmark, left_oper, right_oper):
@@ -117,8 +115,6 @@ def bench_matmul_oper_oper(benchmark, left_oper, right_oper):
     # Benchmark operations
     result = benchmark(matmul, left_oper, right_oper)
 
-    return result
-
 
 @pytest.mark.nightly
 def bench_matmul_oper_ket(benchmark, left_oper, right_ket):
@@ -126,5 +122,3 @@ def bench_matmul_oper_ket(benchmark, left_oper, right_ket):
 
     # Run benchmark
     result = benchmark(matmul, left_oper, right_ket)
-
-    return result

--- a/qutip_benchmark/benchmarks/bench_linear_algebra.py
+++ b/qutip_benchmark/benchmarks/bench_linear_algebra.py
@@ -7,7 +7,9 @@ import numpy as np
 
 # Available datatypes (using qutip_dense and qutip_csr to avoid confusion
 # with density parameters)
-@pytest.fixture(params=["numpy", "scipy_csr", "qutip_dense", "qutip_csr"])
+@pytest.fixture(
+    params=["numpy", "scipy_csr", "qutip_dense", "qutip_csr", "qutip_dia"]
+)
 def dtype(request):
     return request.param
 
@@ -41,6 +43,8 @@ def left_oper(size, density, dtype):
         return res.to("dense")
     if dtype == "qutip_csr":
         return res.to("csr")
+    if dtype == "qutip_dia":
+        return res.to("dia")
     raise Exception("The specified dtype is invalid")
 
 
@@ -63,6 +67,8 @@ def right_oper(size, density, dtype):
         return res.to("dense")
     if dtype == "qutip_csr":
         return res.to("csr")
+    if dtype == "qutip_dia":
+        return res.to("dia")
     raise Exception("The specified dtype is invalid")
 
 
@@ -81,6 +87,8 @@ def right_ket(size, density, dtype):
         return res.to("dense")
     if dtype == "qutip_csr":
         return res.to("csr")
+    if dtype == "qutip_dia":
+        return res.to("dia")
     raise Exception("The specified dtype is invalid")
 
 

--- a/qutip_benchmark/benchmarks/bench_qobjevo.py
+++ b/qutip_benchmark/benchmarks/bench_qobjevo.py
@@ -70,5 +70,3 @@ def bench_matmul_QobjEvo_ket(benchmark, left_QobjEvo, right_ket):
     benchmark.group = "math:matmul:qobjevo-op-times-ket"
 
     result = benchmark(matmul, left_QobjEvo, right_ket)
-
-    return result

--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -147,7 +147,6 @@ def bench_mesolve(benchmark, model_solve, size):
         H, psi0, c_ops, e_ops = qubit_setup(size)
 
     result = benchmark(mesolve, H, psi0, tlist, c_ops, e_ops)
-    return result
 
 
 def bench_mcsolve(benchmark, model_solve, size):
@@ -161,7 +160,6 @@ def bench_mcsolve(benchmark, model_solve, size):
         H, psi0, c_ops, e_ops = qubit_setup(size)
 
     result = benchmark(mcsolve, H, psi0, tlist, c_ops, e_ops, ntraj=1)
-    return result
 
 
 @pytest.mark.nightly
@@ -178,4 +176,3 @@ def bench_steadystate(benchmark, model_steady, size):
         H, _, c_ops, _ = jc_setup(size)
 
     result = benchmark(steadystate, H, c_ops)
-    return result

--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -42,10 +42,10 @@ def jc_setup(size):
 
     # Hamiltonian
     Ia = qutip.qeye(2)
-    Ic = qutip.qeye(size)
+    Ic = qutip.qeye(size, dtype="csr")
 
-    a = qutip.destroy(size)
-    a_dag = qutip.create(size)
+    a = qutip.destroy(size, dtype="csr")
+    a_dag = qutip.create(size, dtype="csr")
     n = a_dag * a
 
     sm = qutip.sigmam()
@@ -169,9 +169,10 @@ def bench_steadystate(benchmark, model_steady, size):
     benchmark.group = "solvers:steadystate"
 
     if model_steady == "Cavity":
-        if size >= 128:
-            pytest.skip("Slow test")
         H, _, c_ops, _ = cavity_setup(size)
+        # Steadystate is bad with Dia.
+        H = H.to("csr")
+        c_ops = [c_ops[0].to("csr")]
 
     elif model_steady == "Jaynes-Cummings":
         H, _, c_ops, _ = jc_setup(size)


### PR DESCRIPTION
- Add benchmark for `DIA`.
- Run steadystate test with `CSR` instead of `DIA`.
- Remove the `return` from benchmark functions. Recent `pytest` raise a warning.