### PR TITLE
Publish without svn

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,10 +57,18 @@ jobs:
           cd website
 
           # Download resources from qutip.github.io repository
-          svn export https://github.com/qutip/qutip.github.io/trunk/css
-          svn export https://github.com/qutip/qutip.github.io/trunk/_includes
-          svn export https://github.com/qutip/qutip.github.io/trunk/header_source
-          svn export https://github.com/qutip/qutip.github.io/trunk/images
+          mkdir css
+          cd css
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/css/bootstrap.css
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/css/site.css
+          cd ..
+
+          mkdir _includes
+          cd _includes
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/footer.html
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/header.html
+          wget https://raw.githubusercontent.com/qutip/qutip.github.io/master/_includes/navbar.html
+          cd ..
 
           # Add additional includes
           cp -r _includes_extra/* _includes


### PR DESCRIPTION
`svn` was disabled for github. See #49.

I replaced it with wget.
`git-sparse-checkout` still need to clone `qutip-github.io` which is large and only a few small files are needed. 
shallow clone can allow only cloning the last commit, but still need to checkout all files from that commit.
