### PR TITLE
Remove deprecated mamba

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: Setup Python
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v5"
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Black
         uses: psf/black@stable

--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -30,15 +30,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: actions-bench
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -67,7 +67,7 @@ jobs:
           python -m qutip_benchmark.cli.run_benchmarks -m nightly -v
 
       - name: Create artefact containing benchmarks
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nightly_benchmarks
           path: .benchmarks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,15 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: actions-bench
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -27,15 +27,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: actions-bench
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
           python -m qutip_benchmark.cli.run_benchmarks -v
 
       - name: Create artefact containing benchmarks
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test_benchmarks
           path: .benchmarks


### PR DESCRIPTION
Mamba forge is no longer supported:
https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/
This will use the default version of miniconda instead.