### PR TITLE
Open an issue when benchmarks fails to upload

### DIFF
--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -79,3 +79,19 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.QUTIP_BENCHMARK_S3_KEYID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.QUTIP_BENCHMARK_S3_SECRET }}
           AWS_EC2_METADATA_DISABLED: true
+
+  finalise:
+    needs: publish
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open Issue on Failure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [[ -z "${{ inputs.open_issue }}" ]] || [[ "${{ inputs.open_issue }}" != "False" ]];
+          then
+            pip install requests
+            python tools/report_failing_tests.py $GITHUB_TOKEN
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,3 +80,19 @@ jobs:
         run: |
           python -m pip install ghp-import
           ghp-import -m "Automatic push by ghp-import" -f -n -p -o -r origin -b gh-pages website/_site
+
+  finalise:
+    needs: publish
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open Issue on Failure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [[ -z "${{ inputs.open_issue }}" ]] || [[ "${{ inputs.open_issue }}" != "False" ]];
+          then
+            pip install requests
+            python tools/report_failing_tests.py $GITHUB_TOKEN
+          fi

--- a/tools/report_failing_tests.py
+++ b/tools/report_failing_tests.py
@@ -1,0 +1,45 @@
+import requests
+import json
+import sys
+import argparse
+from datetime import date
+
+def open_issue(token):
+    url = "https://api.github.com/repos/qutip/qutip-jax/issues"
+    data = json.dumps({
+        "title": f"Automated tests failed on {date.today()}",
+        "labels": ["bug"],
+        "body": "Scheduled test failed!"
+    })
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization" : f"token {token}",
+    }
+
+    post_request = requests.post(url=url, data=data, headers=headers)
+
+    if post_request.status_code == 201:
+        print("Success")
+
+    else:
+        print(
+            "Fail:",
+            post_request.status_code,
+            post_request.reason,
+            post_request.content
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""Open an issue on failed tests."""
+    )
+    parser.add_argument("token")
+    args = parser.parse_args()
+    print(args.token)
+    open_issue(args.token)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Open an issue when nightly benchmarks fail or when they don't upload.
Presently, xspronken is the one who get the message and he is not active, so we can spend some time without realizing.