### PR TITLE
Add a tridiagonal matrix to the benchmarks

### DIFF
--- a/qutip_benchmark/benchmarks/bench_linear_algebra.py
+++ b/qutip_benchmark/benchmarks/bench_linear_algebra.py
@@ -19,7 +19,7 @@ def size(request):
     return request.param
 
 
-@pytest.fixture(params=["dense", "sparse"])
+@pytest.fixture(params=["dense", "sparse", "tridiag"])
 def density(request):
     return request.param
 
@@ -34,6 +34,9 @@ def left_oper(size, density, dtype):
         res = qutip.rand_herm(size, density=1 / size)
     elif density == "dense":
         res = qutip.rand_herm(size, density=1)
+    elif density == "tridiag":
+        a = qutip.destroy(size)
+        res = a + a.dag() + a*a.dag()
 
     if dtype == "numpy":
         return res.full()

--- a/qutip_benchmark/benchmarks/bench_qobjevo.py
+++ b/qutip_benchmark/benchmarks/bench_qobjevo.py
@@ -9,7 +9,7 @@ def size(request):
     return request.param
 
 
-@pytest.fixture(params=["dense", "sparse"])
+@pytest.fixture(params=["dense", "sparse", "tridiag"])
 def density(request):
     return request.param
 
@@ -34,6 +34,10 @@ def left_QobjEvo(size, density, coeftype):
 
     elif density == "dense":
         q_obj = qutip.rand_herm(size, density=1)
+
+    elif density == "tridiag":
+        a = qutip.destroy(size)
+        res = a + a.dag() + a*a.dag()
 
     # Creating coefficients
     tlist = None


### PR DESCRIPTION
We have benchmarks for random sparse and dense matrices, but both are bad scenario for the Dia format.
I added a tridiagonal matrix case to benchmark the Dia operations in situation where they are useful.