### PR TITLE
Setup `python` and `qutip_jax` for buildkite pipeline

### DIFF
--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -30,7 +30,6 @@ steps:
 
       python3 --version
       pip3 --version
-      python3 -c "from qutip import about; about()"
 
       python3 -m benchmark.qutip.runbenchmark -v -s
     agents:

--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -36,8 +36,6 @@ steps:
     agents:
       queue: "juliagpu"
       cuda: "*"
-    env:
-      GROUP: "CUDA"
     timeout_in_minutes: 60
 
   #- label: "Run dynamiqs benchmarks with CUDA"

--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -1,4 +1,5 @@
 steps:
+  ### Julia ###
   - label: "Run QuantumToolbox.jl benchmarks with CUDA"
     plugins:
       - JuliaCI/julia#v1:
@@ -19,10 +20,23 @@ steps:
       GROUP: "CUDA"
     timeout_in_minutes: 60
 
-  #- label: "Run qutip benchmarks with CUDA"
-  #  ...
-  #  env:
-  #    GROUP: "CUDA"
+  ### Python ###
+  - label: "Run QuTiP benchmarks"
+    command: |
+      apt-get update -y
+      apt-get install -y python3-pip
+
+      pip3 install -r benchmark/qutip/requirements.txt
+
+      python3 --version
+      pip3 --version
+      python3 -c "from qutip import about; about()"
+
+      python3 -m benchmark.qutip.runbenchmark -v -s
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    timeout_in_minutes: 60
 
   #- label: "Run dynamiqs benchmarks with CUDA"
   #  ...

--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -21,20 +21,31 @@ steps:
     timeout_in_minutes: 60
 
   ### Python ###
-  - label: "Run QuTiP benchmarks"
+  - label: "Install Python"
+    key: "python"
     command: |
       apt-get update -y
       apt-get install -y python3-pip
 
-      pip3 install -r benchmark/qutip/requirements.txt
-
       python3 --version
       pip3 --version
-
-      python3 -m benchmark.qutip.runbenchmark -v -s
     agents:
       queue: "juliagpu"
       cuda: "*"
+    timeout_in_minutes: 60
+
+  - label: "Run QuTiP benchmarks"
+    depends_on: ["python"]
+    command: |
+      pip3 install -r benchmark/qutip/requirements.txt
+      python3 -m benchmark.qutip.runbenchmark -v -s
+    artifact_paths:
+      - "benchmark/results/*"
+    agents:
+      queue: "juliagpu"
+      cuda: "*"
+    env:
+      GROUP: "CUDA"
     timeout_in_minutes: 60
 
   #- label: "Run dynamiqs benchmarks with CUDA"

--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -20,24 +20,16 @@ steps:
       GROUP: "CUDA"
     timeout_in_minutes: 60
 
-  ### Python ###
-  - label: "Install Python"
-    key: "python"
+  - label: "Run QuTiP benchmarks"
     command: |
       apt-get update -y
       apt-get install -y python3-pip
 
       python3 --version
       pip3 --version
-    agents:
-      queue: "juliagpu"
-      cuda: "*"
-    timeout_in_minutes: 60
 
-  - label: "Run QuTiP benchmarks"
-    depends_on: ["python"]
-    command: |
       pip3 install -r benchmark/qutip/requirements.txt
+
       python3 -m benchmark.qutip.runbenchmark -v -s
     artifact_paths:
       - "benchmark/results/*"

--- a/benchmark/qutip/requirements.txt
+++ b/benchmark/qutip/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.21
 qutip>=5.1
-jax<0.5
+jax[cuda12]<0.5
 qutip-jax>=0.1
 pytest-benchmark==5.1.0

--- a/benchmark/qutip/requirements.txt
+++ b/benchmark/qutip/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.21
+qutip>=5.1
+pytest-benchmark==5.1.0

--- a/benchmark/qutip/requirements.txt
+++ b/benchmark/qutip/requirements.txt
@@ -1,3 +1,5 @@
 numpy>=1.21
 qutip>=5.1
+jax<0.5
+qutip-jax>=0.1
 pytest-benchmark==5.1.0

--- a/benchmark/qutip/runbenchmark.py
+++ b/benchmark/qutip/runbenchmark.py
@@ -1,0 +1,22 @@
+import sys
+import pytest
+
+def run_benchmarks():
+    return pytest.main(
+        [
+            "benchmark/qutip/scripts",
+            "--benchmark-only",
+            "--benchmark-columns=Mean,StdDev,rounds,Iterations",
+            "--benchmark-sort=name",
+            "--benchmark-autosave",
+        ]
+    )
+
+
+def main():
+    exit_code = run_benchmarks()
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/qutip/runbenchmark.py
+++ b/benchmark/qutip/runbenchmark.py
@@ -9,6 +9,7 @@ def run_benchmarks():
             "--benchmark-columns=Mean,StdDev,rounds,Iterations",
             "--benchmark-sort=name",
             "--benchmark-autosave",
+            "--benchmark-storage=./benchmark/results/"
         ]
     )
 

--- a/benchmark/qutip/scripts/bench_jax.py
+++ b/benchmark/qutip/scripts/bench_jax.py
@@ -1,0 +1,28 @@
+import pytest
+from qutip import mesolve, basis, sigmax, sigmaz, CoreOptions
+import jax.numpy as jnp
+import qutip_jax as qj
+import jax
+
+@pytest.mark.jax
+def bench_jax_mesolve(benchmark):
+    benchmark.group = "jax:mesolve"
+    qj.set_as_default()
+
+    try:
+        jax.default_device(jax.devices("gpu")[0])
+    except:
+        # jax.default_device(jax.devices("cpu")[0])
+        raise BaseException("Only available devices are: " + str(jax.devices()))
+    finally:
+        opt = { "method": "diffrax", "normalize_output": False }
+
+        with CoreOptions(default_dtype="jax"):
+            delta = jnp.pi
+            g = 0.2
+            H = delta/2.0 * sigmax()
+            c_ops = [jnp.sqrt(g) * sigmaz()]
+            e_ops = [sigmaz()]
+            psi0 = basis(2, 0)
+            tlist = jnp.linspace(0, 10, 100)
+            benchmark(mesolve, H, psi0, tlist, c_ops, e_ops=e_ops, options=opt)

--- a/benchmark/qutip/scripts/bench_jax.py
+++ b/benchmark/qutip/scripts/bench_jax.py
@@ -1,20 +1,15 @@
 import pytest
-from qutip import mesolve, basis, sigmax, sigmaz, CoreOptions
+import jax
 import jax.numpy as jnp
 import qutip_jax as qj
-import jax
+from qutip import mesolve, basis, sigmax, sigmaz, CoreOptions
 
 @pytest.mark.jax
 def bench_jax_mesolve(benchmark):
     benchmark.group = "jax:mesolve"
     qj.set_as_default()
 
-    try:
-        jax.default_device(jax.devices("gpu")[0])
-    except:
-        # jax.default_device(jax.devices("cpu")[0])
-        raise BaseException("Only available devices are: " + str(jax.devices()))
-    finally:
+    with jax.default_device(jax.devices("gpu")[0]):
         opt = { "method": "diffrax", "normalize_output": False }
 
         with CoreOptions(default_dtype="jax"):

--- a/benchmark/qutip/scripts/bench_mesolve.py
+++ b/benchmark/qutip/scripts/bench_mesolve.py
@@ -1,0 +1,18 @@
+import pytest
+import numpy as np
+from qutip import mesolve, basis, sigmax, sigmaz
+
+@pytest.mark.solvers
+def bench_mesolve(benchmark):
+    benchmark.group = "solvers:mesolve"
+
+    delta = np.pi
+    g = 0.2
+
+    H = delta/2.0 * sigmax()
+    c_ops = [np.sqrt(g) * sigmaz()]
+
+    psi0 = basis(2, 0)
+    tlist = np.linspace(0, 10, 100)
+
+    benchmark(mesolve, H, psi0, tlist, c_ops, e_ops=[sigmaz()])

--- a/benchmark/qutip/scripts/pytest.ini
+++ b/benchmark/qutip/scripts/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    solvers: benchmarks for qutip solvers
+
+python_files = bench_*.py
+python_functions = bench_*

--- a/benchmark/qutip/scripts/pytest.ini
+++ b/benchmark/qutip/scripts/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     solvers: benchmarks for qutip solvers
+    jax: benchmarks for qutip with jax
 
 python_files = bench_*.py
 python_functions = bench_*


### PR DESCRIPTION
This adds benchmarks for qutip using the buildkite pipeline.

Things left to do so far:

- [x] Unify output directory
- [x] Fine tune parameters for pytest-benchmark