### PR TITLE
Fix nightly benchmark

### DIFF
--- a/qutip_benchmark/benchmarks/bench_solvers.py
+++ b/qutip_benchmark/benchmarks/bench_solvers.py
@@ -146,8 +146,7 @@ def bench_mesolve(benchmark, model_solve, size):
     elif model_solve == "Qubit Spin Chain":
         H, psi0, c_ops, e_ops = qubit_setup(size)
 
-    result = benchmark(mesolve, H, psi0, tlist, c_ops, e_ops)
-    return result
+    benchmark(mesolve, H, psi0, tlist, c_ops, e_ops=e_ops)
 
 
 def bench_mcsolve(benchmark, model_solve, size):
@@ -160,8 +159,7 @@ def bench_mcsolve(benchmark, model_solve, size):
     elif model_solve == "Qubit Spin Chain":
         H, psi0, c_ops, e_ops = qubit_setup(size)
 
-    result = benchmark(mcsolve, H, psi0, tlist, c_ops, e_ops, ntraj=1)
-    return result
+    benchmark(mcsolve, H, psi0, tlist, c_ops, e_ops=e_ops, ntraj=1)
 
 
 @pytest.mark.nightly
@@ -176,5 +174,4 @@ def bench_steadystate(benchmark, model_steady, size):
     elif model_steady == "Jaynes-Cummings":
         H, _, c_ops, _ = jc_setup(size)
 
-    result = benchmark(steadystate, H, c_ops)
-    return result
+    benchmark(steadystate, H, c_ops)

--- a/tools/report_failing_tests.py
+++ b/tools/report_failing_tests.py
@@ -5,7 +5,7 @@ import argparse
 from datetime import date
 
 def open_issue(token):
-    url = "https://api.github.com/repos/qutip/qutip-jax/issues"
+    url = "https://api.github.com/repos/qutip/qutip-benchmark/issues"
     data = json.dumps({
         "title": f"Automated tests failed on {date.today()}",
         "labels": ["bug"],


### PR DESCRIPTION
Nightly benchmark have been having warnings for a while and errors were not reported due to a bug in the issue creation script.