### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/benchmark.yml
+++ b/.buildkite/benchmark.yml
@@ -14,8 +14,7 @@ steps:
     artifact_paths:
       - "benchmark/results/*"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       GROUP: "CUDA"
     timeout_in_minutes: 60
@@ -40,8 +39,7 @@ steps:
     artifact_paths:
       - "benchmark/results/qutip/*"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     timeout_in_minutes: 60
 
   #- label: "Run dynamiqs benchmarks with CUDA"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
         !build.pull_request.draft      &&
         (build.branch =~ /master/ || build.pull_request.base_branch =~ /master/)
     agents:
-      queue: "juliagpu"
+      queue: "cuda"
     plugins:
       - staticfloat/forerunner:
           watch: # only trigger the benchmark pipeline if the following folders are updated


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)